### PR TITLE
Fix python3 crash in read_pdata

### DIFF
--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -26,9 +26,12 @@ def read_pdata(obj):
         source = obj.data
     else:
         data = obj.data
-        source = ''
+        if isinstance(data.data, bytes):
+            source = b''
+        elif isinstance(data.data, str):
+            source = ''
         while data is not None:
-            source += bytes_to_str(data.data)
+            source += data.data
             data = data.next
     return source
 

--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -28,7 +28,7 @@ def read_pdata(obj):
         data = obj.data
         source = ''
         while data is not None:
-            source += data.data
+            source += bytes_to_str(data.data)
             data = data.next
     return source
 
@@ -155,4 +155,3 @@ def prop_dict(data):
         props[pd['id']] = pd['value']
 
     return props
-


### PR DESCRIPTION
I had trouble running `perfact-zoperecord` in a python3 environment, caused by some js libraries in the lib folder of my Data.fs.
Error was:
```bash
perfact-zoperecord -c zodbsync_config.py 
Traceback (most recent call last):
  File ".../bin/perfact-zoperecord", line 129, in <module>
    sync.record()
  File ".../lib/python3.5/site-packages/perfact/zodbsync/zodbsync.py", line 618, in record
    self.record_obj(obj, path, recurse=recurse)
  File ".../lib/python3.5/site-packages/perfact/zodbsync/zodbsync.py", line 652, in record_obj
    self.record_obj(obj=child, path=path+'/'+item)
  File ".../lib/python3.5/site-packages/perfact/zodbsync/zodbsync.py", line 652, in record_obj
    self.record_obj(obj=child, path=path+'/'+item)
  File ".../lib/python3.5/site-packages/perfact/zodbsync/zodbsync.py", line 623, in record_obj
    data = mod_read(obj, default_owner=self.default_owner)
  File ".../lib/python3.5/site-packages/perfact/zodbsync/zodbsync.py", line 170, in mod_read
    meta.update(dict(handler.read(obj)))
  File ".../lib/python3.5/site-packages/perfact/zodbsync/object_types.py", line 332, in read
    source = read_pdata(obj)
  File ".../lib/python3.5/site-packages/perfact/zodbsync/helpers.py", line 31, in read_pdata
    source += data.data
TypeError: Can't convert 'bytes' object to str implicitly
```

Fix seems pretty straight forward to me.