### PR TITLE
Change recording of unicode in meta files

### DIFF
--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -8,6 +8,19 @@ PY2 = (sys.version_info.major <= 2)
 if not PY2:
     unicode = str
 
+def to_string(value, enc='utf-8'):
+    '''This method delivers bytes in python2 and unicode in python3.'''
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, unicode):
+        return value.encode(enc)
+    elif isinstance(value, bytes):
+        return value.decode(enc)
+    try:
+        return str(value)
+    except:
+        pass
+    raise ValueError("could not convert '%s' to string!" % repr(value))
 
 # Helper function to generate str from bytes (Python3 only)
 def bytes_to_str(value, enc='utf-8'):
@@ -21,13 +34,6 @@ def str_to_bytes(value, enc='utf-8'):
         return value.encode(enc)
     return value
 
-
-def unicode_to_str(value, enc='utf-8'):
-    if PY2 and isinstance(value, unicode):
-        return value.encode(enc)
-    return value
-
-
 # replacement mapping
 repl = {chr(i): '\\x{:02x}'.format(i) for i in range(32)}
 # nicer formattings for some values
@@ -35,13 +41,63 @@ repl.update({'\n': '\\n', '\r': '\\r', '\t': '\\t'})
 # make sure backslash is escaped first
 repl = [('\\', '\\\\')] + sorted(repl.items())
 
+'''
+Test cases for the doctests so we have one less level of escaping to worry
+about. There are different test cases that are accessed by index. Each test
+case consists of an input to str_repr and the desired output.
+TODO: Rewrite as unit test instead of doctest.
+'''
+str_repr_tests = [
+    ['äöüßáéí\n\r\t',
+     "'äöüßáéí\\n\\r\\t'"],
+
+    ['args="1, 2, 3"',
+     "'args=\"1, 2, 3\"'"],
+
+    [True,
+     'True'],
+
+    [('args', 'id=None, tn=False, streaming=True'),
+     "('args', 'id=None, tn=False, streaming=True')"],
+]
 
 def str_repr(val):
-    '''Generic string representation of a value, used to serialize metadata
+    '''
+    Generic string representation of a value, used to serialize metadata.
+    This supports
+    a) strings (bytes in python 2 or unicode in python 3)
+    b) other basic types (boolean, None, integer, float)
+    c) lists and tuples with elements of a)-c)
 
-    >>> (str_repr(u'öäüßáéí\\n\\r\\t') ==
-    ...  unicode_to_str(u"u'öäüßáéí\\\\n\\\\r\\\\t'"))
-    True
+    One might assume that a most stringent representation would always prefix
+    string values with either b or u to denote bytes or unicode. However,
+    properties that were stored as bytes in Python2 (like many titles) usually
+    have become unicode in Python3. In a default PerFact installation, these
+    properties were always *meant* to be UTF-8 encoded text. So the best
+    representation is to store them without prefix and with as few escapes as
+    possible (so no \xc3\xbc, but simply ü). The only characters that need to
+    be escaped are unprintables, white space, backslash and the quoting
+    character. To keep the diff to older versions smaller, we also check if
+    there is a ' but no " inside, switching the enclosing quotation marks.
+
+    Even properties that are already unicode in Python 2 do not complain if
+    being set with a bytes value, interpreting it correctly as UTF-8.
+    
+    This strategy ensures
+    a) that the contents of both bytes and unicode properties are transferred
+    correctly when recording in Python 2 and playing back in Python 2
+    b) that the contents of both bytes and unicode properties are transferred
+    correctly when recording in Python 2 and playing back in Python 3
+    c) That there is no diff if any of these played back properties is
+    re-recorded
+
+
+    >>> comp = [
+    ...     (str_repr(item[0]), item[1])
+    ...     for item in str_repr_tests
+    ... ]
+    >>> [item for item in comp if item[0] != item[1]]
+    []
     '''
 
     if isinstance(val, list):
@@ -51,19 +107,6 @@ def str_repr(val):
         return fmt % ', '.join(str_repr(item) for item in val)
 
     if PY2 and isinstance(val, (bytes, unicode)):
-        '''
-        One might assume that a most stringent representation would always
-        prefix the value with either b or u to denote bytes or unicode.
-        However, properties that were stored as bytes in Python2 (like
-        title) usually have become unicode in Python3. In a default PerFact
-        installation, these properties were always *meant* to be UTF-8
-        encoded text. So the best representation is to store them without
-        prefix and with as few escapes as possible (so no \xc3\xbc, but
-        simply ü). The only characters that need to be escaped are
-        unprintables, white space, backslash and the quoting character.
-        To keep the diff to older versions smaller, we also check if there
-        is a ' but no " inside, switching the enclosing quotation marks.
-        '''
         is_unicode = isinstance(val, unicode)
         for orig, r in repl:
             val = val.replace(orig, r)
@@ -78,7 +121,7 @@ def str_repr(val):
 
         return ("u" if is_unicode else "") + quote + val + quote
     else:
-        return 'u' + repr(val)
+        return repr(val)
 
 
 # Functions copied from perfact.generic

--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -105,6 +105,8 @@ def str_repr(val):
     Python version to another ('testü' is a bytes array in Python2 containing
     6 bytes that are meant to represent the given 5 characters, while it is a
     unicode array in Python 3, stored in memory in some irrelevant manner).
+    The only characters being escaped are the unprintables (ASCII values 0-31),
+    the backslash and, if necessary, the quoting character.
 
     This also ensures that recording metadata in Python 2, sending it through
     2to3, playing it back in Python 3 and recording it again will a) restore
@@ -144,15 +146,14 @@ def str_repr(val):
             val.decode('utf-8')
         except UnicodeDecodeError:
             return 'b' + repr(val)
+
         for orig, r in repl:
             val = val.replace(orig, r)
+
         if ("'" in val) and not ('"' in val):
-            quote = '"'
+            return '"%s"' % val
         else:
-            quote = "'"
-        if quote == "'":
-            val = val.replace("'", "\\'")
-        return quote + val + quote
+            return "'%s'" % val.replace("'", "\\'")
     else:
         return repr(val)
 

--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -59,7 +59,7 @@ def str_repr(val):
             val = val.replace(orig, r)
 
         if quote == "'":
-            val = val.replace("'", "\'")
+            val = val.replace("'", "\\'")
 
         return ("u" if is_unicode else "") + quote + val + quote
     else:

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -20,10 +20,11 @@ import AccessControl.SecurityManagement
 # stdout)
 import logging
 # Plugins for handling different object types
-from perfact.zodbsync.object_types import object_handlers, \
-        mod_implemented_handlers
+from perfact.zodbsync.object_types import object_handlers,\
+    mod_implemented_handlers
 
-from perfact.zodbsync.helpers import str_repr, to_string, literal_eval, fix_encoding
+from perfact.zodbsync.helpers import str_repr, to_string, literal_eval,\
+    fix_encoding
 
 PY2 = (sys.version_info.major == 2)
 

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -73,20 +73,23 @@ def mod_format(data=None, indent=0, as_list=False):
             installation, these properties were always *meant* to be UTF-8
             encoded text. So the best representation is to store them without
             prefix and with as few escapes as possible (so no \xc3\xbc, but
-            simply ü).  The only characters that need to be escaped are \n, \\
-            and \' (because we enclose the expression in '').
+            simply ü).  The only characters that need to be escaped are \n, \r,
+            \\ and \' (because we enclose the expression in '').
             To keep the diff to older versions smaller, we also check if there
             is a ' but no " inside, switching the enclosing quotation marks.
             '''
             is_unicode = isinstance(val, unicode)
             if is_unicode:
                 val = val.encode('utf-8')
-            val = val.replace('\\', '\\\\').replace('\n', '\\n')
-            quote = "'"
+            # replacements
+            repl = [('\\', '\\\\'), ('\n', '\\n'), ('\r', '\\r')]
             if ("'" in val) and not ('"' in val):
                 quote = '"'
             else:
-                val = val.replace("'", "\\'")
+                quote = "'"
+                repl.append(("'", "\\'"))
+            for orig, r in repl:
+                val = val.replace(orig, r)
 
             return ("u" if is_unicode else "") + quote + val + quote
         else:

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -112,6 +112,7 @@ def mod_read(obj=None, onerrorstop=False, default_owner=None):
 
     # The title should always be readable
     title = getattr(obj, 'title', None)
+    # see comment in helpers.py:str_repr for why we convert to string
     meta['title'] = to_string(title)
 
     # Generic and meta type dependent handlers

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -55,46 +55,6 @@ def mod_format(data=None, indent=0, as_list=False):
     <as_list> is True.
     '''
 
-    def str_repr(val):
-        '''Generic string representation of a value'''
-
-        if isinstance(val, list):
-            return '[%s]' % ', '.join(str_repr(item) for item in val)
-        elif isinstance(val, tuple):
-            fmt = '(%s,)' if len(val) == 1 else '(%s)'
-            return fmt % ', '.join(str_repr(item) for item in val)
-
-        if PY2 and isinstance(val, (bytes, unicode)):
-            '''
-            One might assume that a most stringent representation would always
-            prefix the value with either b or u to denote bytes or unicode.
-            However, properties that were stored as bytes in Python2 (like
-            title) usually have become unicode in Python3. In a default PerFact
-            installation, these properties were always *meant* to be UTF-8
-            encoded text. So the best representation is to store them without
-            prefix and with as few escapes as possible (so no \xc3\xbc, but
-            simply ü).  The only characters that need to be escaped are \n, \r,
-            \\ and \' (because we enclose the expression in '').
-            To keep the diff to older versions smaller, we also check if there
-            is a ' but no " inside, switching the enclosing quotation marks.
-            '''
-            is_unicode = isinstance(val, unicode)
-            if is_unicode:
-                val = val.encode('utf-8')
-            # replacements
-            repl = [('\\', '\\\\'), ('\n', '\\n'), ('\r', '\\r')]
-            if ("'" in val) and not ('"' in val):
-                quote = '"'
-            else:
-                quote = "'"
-                repl.append(("'", "\\'"))
-            for orig, r in repl:
-                val = val.replace(orig, r)
-
-            return ("u" if is_unicode else "") + quote + val + quote
-        else:
-            return str((val,))[1:-2]
-
     # Convert dictionary to sorted list of tuples (diff-friendly!)
     if isinstance(data, dict):
         data = [(key, value) for key, value in data.items()]

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -112,7 +112,7 @@ def mod_read(obj=None, onerrorstop=False, default_owner=None):
 
     # The title should always be readable
     title = getattr(obj, 'title', None)
-    meta['title'] = title
+    meta['title'] = to_string(title)
 
     # Generic and meta type dependent handlers
 


### PR DESCRIPTION
The goal is to change the representation of string metadata in Python 2 to give something like

    -    ('title', 'VNC-Displaykopplung nachr\xc3\xbcsten'),
    +    ('title', 'VNC-Displaykopplung nachrüsten'),

which makes the transition to Python 3 easier.
It might need to be checked if Zope2 installations not using UTF-8 have to be supported and how to handle them.