### PR TITLE
In playback, set owner to default owner if it not given on the FS

### DIFF
--- a/perfact/zodbsync/object_types.py
+++ b/perfact/zodbsync/object_types.py
@@ -495,6 +495,8 @@ class PropertiesObj(ModObj):
         # Keep the items sorted and hash-friendly
         for item in props:
             item.sort()
+        # Sort the properties
+        props.sort()
 
         if props:
             meta.append(('props', props))

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -231,7 +231,7 @@ def mod_write(data, parent=None, obj_id=None, override=False, root=None,
 
     # Send an update (depending on type)
     for handler in mod_implemented_handlers(obj, meta_type):
-        handler.write(obj, data)
+        handler.write(obj, d)
 
     result['obj'] = obj
     return result


### PR DESCRIPTION
`mod_write` created a copy `d` of `data` to make sure it was using a dict instead of a list of tuples. If no owner was defined in the filesystem data, the default owner was inserted into `d`, but `data` was passed to the corresponding handler.