### PR TITLE
Allow commit ranges to be picked

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.14.0.dev1
+  * Allow picking commit ranges by using COMMIT1..COMMIT2
+
 3.14.0.dev0
   * Switch to using a single excutable `zodbsync` with subcommands like
     `record`, `playback`, `watch` and `pick`, opening the way to add further

--- a/perfact/zodbsync/__init__.py
+++ b/perfact/zodbsync/__init__.py
@@ -1,1 +1,3 @@
 from perfact.zodbsync.zodbsync import mod_read, mod_write, obj_modtime
+
+__all__ = ['mod_read', 'mod_write', 'obj_modtime']

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages=[
         'perfact',
         'perfact.zodbsync',
+        'perfact.zodbsync.commands',
     ],
     package_data={
     },


### PR DESCRIPTION
In addition, this finally `pep8`s `object_types.py` and fixes two issues that were overlooked in the refactoring for 3.14.0.dev0, namely a missing inclusion of the submodule `perfact.zodbsync.commands` and calls to `git` not being wrapped correctly.

I guess it is high time to think about how to wrap this module in tests.