### PR TITLE
Fix lookup of parent in external editor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+3.15.1.dev0
+  * Fix lookup of parent in external editor to avoid creating a new object when
+    trying to edit an existing one but using it in an acquired context.
+
 3.15.0
   * Fix dry-run mode for repositories that have an upstream remote.
 

--- a/perfact/zodbsync/extedit.py
+++ b/perfact/zodbsync/extedit.py
@@ -66,7 +66,7 @@ def read_obj(context, path, force_encoding=None):
             continue
         obj = getattr(obj, part)
     result = mod_read(obj)
-    result['parent'] = obj.aq_parent
+    result['parent'] = obj.aq_inner.aq_parent
 
     encoding = force_encoding
     if force_encoding and isinstance(result['source'], str):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setuptools.setup(
     name='perfact-zodbsync',
-    version='3.15.0',
+    version='3.15.1.dev0',
     description='Zope Recorder and Playback',
     long_description=''' ''',
     author='Ján Jockusch et.al.',


### PR DESCRIPTION
If the external editor is invoked with a path that leads to an object
not in its container but in an acquired context, saving changes to the
object could have the effect of creating a copy of the object instead.

For example, if a script called 'myscript' is located in / but accessed
with a path of /myfolder/myscript, Saving changes would create a
modified copy in /myfolder.