### PR TITLE
Do not break when recording new objects

### DIFF
--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -407,7 +407,7 @@ class ZODBSync:
         except IOError:
             old_data = None
 
-        if old_data.strip() != fmt.strip():
+        if old_data is None or old_data.strip() != fmt.strip():
             self.logger.debug("Will write %d bytes of metadata" % len(fmt))
             with open(data_fname, 'wb') as f:
                 f.write(fmt)


### PR DESCRIPTION
This fixes a bug introduced in #35 where new objects could no longer be
recorded because the comparison of old and new metadata was done after
stripping both of whitespaces without considering that one might be
`None`.