### PR TITLE
Allow installation under Zope 5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 3.15.2.dev0
+  * Relax dependency to allow installation under Zope 5
+
   * Fix bytes/str bug with watcher under Python 3 after packing the Data.FS.
 
   * Add issue template for github.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ reqs = ['filelock']
 if sys.version_info.major == 2:
     reqs.extend(['ZODB3', 'Zope2'])
 else:
-    reqs.extend(['ZODB', 'Zope<5'])
+    reqs.extend(['ZODB', 'Zope'])
 
 setuptools.setup(
     name='perfact-zodbsync',


### PR DESCRIPTION
When Zope 5 had not been released yet, the tests failed if the version was not pinned, but that seems to be fixed now.