### PR TITLE
Add subcommand `with-lock`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 4.0.2.dev0
+  * Clean up Python 2 compatibility code
+  
+  * Add subcommand with-lock and option --no-lock
 
 4.0.1
   * Add upload subcommand to push JS/CSS files into the Data.fs

--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ Example to upload bootstrap:
 
     zodbsync upload /tmp/bootstrap lib/bootstrap
 
+### `zodbsync with-lock`
+
+If some combination of `git` and `zodbsync` operations is not yet covered by a
+wrapper subcommand, it is possible to use `zodbsync with-lock` to execute a
+series of commands while still making sure that no other similar operation
+interferes. Any `zodbsync` command used as part of this must then use the
+option `--no-lock`. For example:
+
+    zodbsync with-lock "git rebase origin/main && zodbsync --no-lock playback /"
+
 ## Compatibility
 This package replaces similar functionality that was previously found in
 `python-perfact` and `perfact-dbutils-zope2`. For backwards compatibility,

--- a/config.py
+++ b/config.py
@@ -1,10 +1,10 @@
 # Path of the Zope instance configuration to use to
 # instantiate Zope2.app()
-conf_path = '/var/lib/zope2.13/instance/ema/etc/zope.conf'
+wsgi_conf_path = '/var/lib/zope4/ema/etc/zope.conf'
 
 # Path to Data.fs which is needed for lookup of object IDs from transaction IDs
 # with perfact-zoperecord --watch
-datafs_path = '/var/lib/zope2.13/zeo/emazeo/var/Data.fs'
+datafs_path = '/var/lib/zope4/zeo/var/Data.fs'
 
 # user that is used to create commits and as default owner of objects
 manager_user = 'perfact'

--- a/perfact/zodbsync/commands/watch.py
+++ b/perfact/zodbsync/commands/watch.py
@@ -337,7 +337,7 @@ class Watch(SubCommand):
         self.app = self.sync.app
 
         try:
-            self.datafs_path = self.config.datafs_path
+            self.datafs_path = self.config["datafs_path"]
         except AttributeError:
             self.logger.exception("watch requires datafs_path in config")
             raise

--- a/perfact/zodbsync/main.py
+++ b/perfact/zodbsync/main.py
@@ -7,12 +7,13 @@ from .commands.playback import Playback
 from .commands.watch import Watch
 from .commands.pick import Pick
 from .commands.upload import Upload
+from .commands.with_lock import WithLock
 
 # Future ideas:
 # from .commands.reset import Reset
 # from .commands.rebase import Rebase
 
-commands = [Record, Playback, Watch, Pick, Upload]
+commands = [Record, Playback, Watch, Pick, Upload, WithLock]
 
 
 def create_runner(argv=None):

--- a/perfact/zodbsync/object_types.py
+++ b/perfact/zodbsync/object_types.py
@@ -191,7 +191,7 @@ class DTMLDocumentObj(ModObj):
         return
 
     def read(self, obj):
-        return [('source', helpers.str_to_bytes(
+        return [('source', helpers.to_bytes(
             helpers.simple_html_unquote(str(obj))
         ))]
 
@@ -199,7 +199,7 @@ class DTMLDocumentObj(ModObj):
         d = dict(data)
 
         obj.manage_edit(
-            data=helpers.bytes_to_str(d['source']),
+            data=helpers.to_string(d['source']),
             title=d['title'])
         return
 
@@ -252,7 +252,7 @@ class ZSQLMethodObj(ModObj):
         obj.manage_addProduct['ZSQLMethods'].manage_addZSQLMethod(
             id=obj_id, title=d['title'],
             connection_id=d['connection_id'],
-            arguments=d['args'], template=helpers.bytes_to_str(d['source']))
+            arguments=d['args'], template=helpers.to_string(d['source']))
         return
 
     def read(self, obj):
@@ -261,7 +261,7 @@ class ZSQLMethodObj(ModObj):
         meta.append(('args', args))
         connection_id = obj.connection_id
         meta.append(('connection_id', connection_id))
-        meta.append(('source', helpers.str_to_bytes(obj.src)))
+        meta.append(('source', helpers.to_bytes(obj.src)))
 
         # Advanced tab
         advanced = {
@@ -286,7 +286,7 @@ class ZSQLMethodObj(ModObj):
             title=d['title'],
             connection_id=d['connection_id'],
             arguments=d['args'],
-            template=helpers.bytes_to_str(d['source']))
+            template=helpers.to_string(d['source']))
 
         # Advanced settings
         adv = dict(d['advanced'])
@@ -591,7 +591,7 @@ class ScriptPythonObj(ModObj):
         bindmap.sort()
         meta.append(('bindings', bindmap))
         meta.append(('args', obj.params()))
-        meta.append(('source', helpers.str_to_bytes(obj.body())))
+        meta.append(('source', helpers.to_bytes(obj.body())))
 
         # Proxy roles
 
@@ -608,7 +608,7 @@ class ScriptPythonObj(ModObj):
         d = dict(data)
         obj.ZPythonScript_setTitle(title=d['title'])
         obj.ZPythonScript_edit(params=d['args'],
-                               body=helpers.bytes_to_str(d['source']))
+                               body=helpers.to_string(d['source']))
         obj.ZBindings_edit(mapping=dict(d['bindings']))
         obj.manage_proxy(roles=d['proxy_roles'])
         return


### PR DESCRIPTION
This allows wrapping a series of shell commands in the file lock.

Additionally, some code cleanup was performed in the Python 2
compatibility wrappers, using `six` where this is applicable and using
current implementations of some helper functions that are also present
in `python-perfact`.