### PR TITLE
Switch tests to use a socket for the ZEO connection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.4.dev0
+  * Switch tests to use a socket for the ZEO connection
+
 4.0.3
   * Delete roles and local roles on playback if they are not set in the file
     (#22)

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -8,9 +8,6 @@ import perfact.zodbsync.helpers as helpers
 import perfact.zodbsync.tests.environment as env
 
 
-ZEOPORT = 9011
-
-
 class TestSync():
     '''
     All tests defined in this class automatically use the environment fixture
@@ -23,12 +20,11 @@ class TestSync():
         Fixture that is automatically used by all tests. Initializes
         environment and injects the elements of it into the class.
         '''
-        myenv = {
-            'zeo': env.ZeoInstance(port=ZEOPORT),
-            'repo': env.Repository(),
-            'zopeconfig': env.ZopeConfig(zeoport=ZEOPORT),
-            'jslib': env.JSLib(),
-        }
+        myenv = {}
+        myenv['zeo'] = env.ZeoInstance()
+        myenv['repo'] = env.Repository()
+        myenv['zopeconfig'] = env.ZopeConfig(zeosock=myenv['zeo'].sockpath())
+        myenv['jslib'] = env.JSLib()
         myenv['config'] = env.ZODBSyncConfig(env=myenv)
 
         # inject items into class so methods can use them

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setuptools.setup(
     name='perfact-zodbsync',
-    version='4.0.3',
+    version='4.0.4.dev0',
     description='Zope Recorder and Playback',
     long_description=''' ''',
     author='Ján Jockusch et.al.',


### PR DESCRIPTION
Tests that spawn a ZEO process now use a socket to communicate with it
instead of hoping that the hardcoded port is not used anywhere else. In
particular, if a test run fails abnormally and fails to clean up, there
might still be a spawned process left running, but it will not confuse
following test runs.