### PR TITLE
Restore graceful shutdown of watcher

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 4.0.4.dev0
+  * Restore graceful shutdown of watcher
+
   * Switch tests to use a socket for the ZEO connection
 
 4.0.3


### PR DESCRIPTION
I'm afraid something else was broken with the 4.0.2 release. The signal handler for graceful shutdown of the watcher used `exit`, but since it was moved to a separate function, `exit` was not the `Signal` object that it was supposed to be.