### PR TITLE
Fix playback of local_roles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 4.0.5.dev0
+  * Fix playback of local roles
 
 4.0.4
   * Restore graceful shutdown of watcher

--- a/perfact/zodbsync/commands/watch.py
+++ b/perfact/zodbsync/commands/watch.py
@@ -14,8 +14,6 @@ import ZODB.FileStorage
 
 # for making an annotation to the transaction
 import transaction
-# for "logging in"
-import AccessControl.SecurityManagement
 
 from ..subcommand import SubCommand
 from ..helpers import remove_redundant_paths

--- a/perfact/zodbsync/object_types.py
+++ b/perfact/zodbsync/object_types.py
@@ -41,15 +41,6 @@ class AccessControlObj(ModObj):
             if role[1] != ('Owner',)]
         ))
 
-    @staticmethod
-    def local_roles_to_dict(roles):
-        """Transform list of tuples (uid, role) to dict {uid: [roles]}"""
-        users = {item[0] for item in roles}
-        return {
-            user: [item[1] for item in roles if item[0] == user]
-            for user in users
-        }
-
     def read(self, obj):
         ac = []
 
@@ -119,12 +110,12 @@ class AccessControlObj(ModObj):
             obj._delRoles(todelete)
 
         # Set local roles
-        cur = self.local_roles_to_dict(self.local_roles(obj))
-        tgt = self.local_roles_to_dict(d.get('local_roles', []))
+        cur = dict(self.local_roles(obj))
+        tgt = dict(d.get('local_roles', tuple()))
         users = set(cur.keys()) | set(tgt.keys())
         for user in users:
             if cur.get(user) != tgt.get(user):
-                obj.manage_setLocalRoles(user, tgt.get(user, []))
+                obj.manage_setLocalRoles(user, tgt.get(user, tuple()))
 
         # Permission settings
         # permissions that are not stored are understood to be acquired, with


### PR DESCRIPTION
The fix for #22 in 4.0.3 wrongly assumed that get_local_roles() returns
a list of (user, role) pairs. Instead, it returns a list of (user,
roles) pairs, where the second element is a tuple of roles. This wrote
broken content into the object when playing it back.