### PR TITLE
Clear sys arguments before calling configure_zope in zope2

### DIFF
--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -16,8 +16,10 @@ import Zope2.App.startup
 import App.config
 try:
     from Zope2.Startup.run import configure_wsgi as configure_zope
+    zope_version = 4
 except ImportError:
     from Zope2.Startup.run import configure as configure_zope
+    zope_version = 2
 
 # Plugins for handling different object types
 from .object_types import object_handlers, mod_implemented_handlers
@@ -245,6 +247,10 @@ class ZODBSync:
         conf_path = self.config.get('wsgi_conf_path')
         if not conf_path:
             conf_path = self.config.get('conf_path')
+
+        # clear arguments to avoid confusing zope2 configuration procedure
+        if zope_version == 2:
+            sys.argv = sys.argv[:1]
 
         # Read and parse configuration
         configure_zope(conf_path)


### PR DESCRIPTION
Found on a customer system using zope2, zodbsync stopped working with following error:

```
$ zodbsync watch
Error: positional arguments are not supported
For help, use /usr/share/perfact/zope2.13/bin/zodbsync -h
```
This PR should fix this error by clearing sys arguments before calling `configure_zope`