### PR TITLE
T211837: Fix timing issues in watcher

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.1.5.dev0
+  * Fix timing issues in watcher
+
 4.1.4
   * Add subcommand `exec` to capture many git operations
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setuptools.setup(
     name='perfact-zodbsync',
-    version='4.1.4',
+    version='4.1.5.dev0',
     description='Zope Recorder and Playback',
     long_description=''' ''',
     author='Ján Jockusch et.al.',


### PR DESCRIPTION
Since I could not find a way to get the current transaction ID after
starting a transaction, lastTransaction() should be read before the
transaction is started. This ensures that we do not read an old state
and miss important changes in all further updates because we already
assumed we were reading the state at the transaction stored in
`self.last_visible_transaction`.

Fixes #73.