### PR TITLE
Allow recreating the top-level User Folder if it is accidentally deleted

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 4.2.3.dev0
+  * Allow recreating the top-level User Folder if it is accidentally deleted.
 
 4.2.2
   * Handle changes between "Folder" and "Folder (Ordered)" in playback without

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -1116,3 +1116,19 @@ class TestSync():
         assert self.app.Test.meta_type == 'Folder'
         assert sorted(self.app.Test.objectIds()) == ['A', 'B', 'C']
         assert self.app.Test.A._p_oid == orig_oid
+
+    def test_create_userfolder(self):
+        """
+        Check that we can recover from a state where the top-level userfolder
+        was deleted.
+        Note that we here call create_manager_user manually, but this is not
+        necessary when using zodbsync playback, since it is called upon
+        initialization of the ZODBSync class if the config variable is set
+        accordingly. But since the test tries to avoid tearing down and
+        recreating the class instance, we need to call it manually.
+        """
+        with self.runner.sync.tm:
+            self.app.manage_delObjects('acl_users')
+            self.runner.sync.create_manager_user()
+        self.run('playback', '/')
+        assert self.app.acl_users.meta_type == 'User Folder'

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -1122,9 +1122,9 @@ class TestSync():
         Check that we can recover from a state where the top-level userfolder
         was deleted.
         Note that we here call create_manager_user manually, but this is not
-        necessary when using zodbsync playback, since it is called upon
-        initialization of the ZODBSync class if the config variable is set
-        accordingly. But since the test tries to avoid tearing down and
+        necessary when using `zodbsync playback` since it is called upon
+        initialization of the `ZODBSync` class instance if the config variable
+        is set accordingly. But since the test tries to avoid tearing down and
         recreating the class instance, we need to call it manually.
         """
         with self.runner.sync.tm:

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -278,7 +278,10 @@ class ZODBSync:
         """
         Make sure the manager user exists.
         """
-        userfolder = self.app.acl_users
+        userfolder = getattr(self.app, 'acl_users', None)
+        if userfolder is None:
+            self.app.manage_addProduct['OFSP'].manage_addUserFolder()
+            userfolder = self.app.acl_users
         user = userfolder.getUser(self.manager_user)
         if user is not None:
             return


### PR DESCRIPTION
Since we added `/acl_users` to the `.gitignore` file, I repeatedly accidentally played back a freshly cloned repository that was missing this top-level User Folder, deleting it. `zodbsync` was unable to recreate it, assuming it exists beforehand.

This PR changes the initialization so it creates this top-level User Folder if it is missing and `create_manager_user` is set in the config.