### PR TITLE
Restart on filesystem diff

### DIFF
--- a/perfact/zodbsync/commands/watch.py
+++ b/perfact/zodbsync/commands/watch.py
@@ -322,6 +322,7 @@ class Watch(SubCommand):
                 except OSError as err:
                     if err.errno == 2:  # no such file or directory
                         raise TreeOutdatedException()
+                    self.logger.exception('Unexpected OSError')
                     raise
                 self._update_path(child_oid, newpath)
 

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -23,7 +23,6 @@ from .. import helpers
 from .. import extedit
 from .. import object_types
 from . import environment as env
-from ..commands import watch
 
 
 class DummyResponse():
@@ -906,10 +905,7 @@ class TestSync():
         self.run('playback', '/')
 
         # wait for watch to notices played back changes
-        with pytest.raises(watch.TreeOutdatedException):
-            self.watcher_step_until(watcher, lambda: True)
-        # release the lock the same way the watcher process does
-        watcher.release_lock()
+        self.watcher_step_until(watcher, watcher.exit.is_set)
 
     def test_commit_on_branch_and_exec_merge(self):
         '''

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -904,7 +904,6 @@ class TestSync():
 
         # playback changes and check if those are existent in zodb
         self.run('playback', '/')
-        # assert new_title == self.app.folder_1.s_folder_1.title
 
         # wait for watch to notices played back changes
         with pytest.raises(watch.TreeOutdatedException):


### PR DESCRIPTION
This PR aims to resolve #60 by correctly shutting down the watcher in case the filesystem does not match the currently stored tree! This PR also adds a Test-Case to validate that the correct Exception is thrown in the described use case!