### PR TITLE
Avoid piping git output to pager

### DIFF
--- a/perfact/zodbsync/subcommand.py
+++ b/perfact/zodbsync/subcommand.py
@@ -58,7 +58,7 @@ class SubCommand(Namespace):
         return wrapper
 
     def gitcmd(self, *args):
-        return ['git', '-C', self.sync.base_dir] + list(args)
+        return ['git', '-P', '-C', self.sync.base_dir] + list(args)
 
     def gitcmd_run(self, *args):
         '''Wrapper to run a git command.'''

--- a/perfact/zodbsync/subcommand.py
+++ b/perfact/zodbsync/subcommand.py
@@ -58,7 +58,8 @@ class SubCommand(Namespace):
         return wrapper
 
     def gitcmd(self, *args):
-        return ['git', '-P', '-C', self.sync.base_dir] + list(args)
+        # use "--no-pager" instead of "-P" for compatibility / readability
+        return ['git', '--no-pager', '-C', self.sync.base_dir] + list(args)
 
     def gitcmd_run(self, *args):
         '''Wrapper to run a git command.'''


### PR DESCRIPTION
During bootcamp we encountered a nasty behaviour: One person calling a `pick` with conflicts, `git diff` output is piped into pager, keeping zodbsync lock! Second person gets `Unable to acquire lock.` . Simple solution is this PR, stopping git from piping to pager via `-P` option.