### PR TITLE
Multiple recipients in codechange mail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+4.3.4
+  * Add support for a whitespace-separated list of recipient addresses for the
+    codechange email.
+
 4.3.3
   * Make reformat robust against newline changes
 

--- a/perfact/zodbsync/commands/record.py
+++ b/perfact/zodbsync/commands/record.py
@@ -65,12 +65,17 @@ class Record(SubCommand):
             msg = MIMEText(status, 'plain', 'utf-8')
             msg['Subject'] = 'Commit summary on {} ({})'.format(pfsystemname,
                                                                 pfsystemid)
-            msg['To'] = codechg_mail
+
+            recipients = codechg_mail.split()
+            for recipient in recipients:
+                msg['To'] = recipient
+
             msg['From'] = self.config.get('codechange_sender',
                                           'codechanges@perfact.de')
 
+
             smtp = smtplib.SMTP('localhost')
-            smtp.sendmail(msg['From'], [codechg_mail, ], msg.as_string())
+            smtp.sendmail(msg['From'], recipients, msg.as_string())
             smtp.quit()
 
         if self.args.autoreset:


### PR DESCRIPTION
Add support to add a whitelist-separated list of email addresses to the codechange_email.