### PR TITLE
Allow for a callable title on objects in ZODB.

### DIFF
--- a/.toxfiles/reqs-py2.txt
+++ b/.toxfiles/reqs-py2.txt
@@ -1,2 +1,3 @@
 zope.mkzeoinstance==3.9.6
 Products.ZSQLMethods==2.13.6
+mock

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+unreleased
+  * Omit title attributes if they are callable.
+
 22.2.4
   * Refactor scripts into entry points to be usable with zc.buildout >= 3.
 

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -18,6 +18,11 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     ZOPE2 = False
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from ..main import Runner
 from .. import zodbsync
 from .. import helpers
@@ -242,6 +247,29 @@ class TestSync():
         assert 'unsupported' in zodbsync.mod_read(obj)
         with pytest.raises(AssertionError):
             zodbsync.mod_read(obj, onerrorstop=True)
+
+    def test_record_callable_title(self):
+        """Check that callable titles are supported on objects."""
+        app = self.app
+        obj = app.manage_addProduct['PageTemplates'].manage_addPageTemplate(
+            id='test_pt', title='Not-visible', text='test text')
+
+        def patch_title():
+            """Callable to test callable titles."""
+            return 'Show-me'
+
+        # Normal case
+        result = zodbsync.mod_read(obj)
+        assert 'Not-visible' in result['title']
+        assert 'Show-me' not in result['title']
+        assert 'test text' in result['source']
+
+        # with callable
+        with mock.patch.object(obj, 'title', patch_title):
+            result = zodbsync.mod_read(obj)
+            assert 'Not-visible' not in result['title']
+            assert 'Show-me' in result['title']
+            assert 'test text' in result['source']
 
     def test_playback(self):
         '''

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -248,8 +248,8 @@ class TestSync():
         with pytest.raises(AssertionError):
             zodbsync.mod_read(obj, onerrorstop=True)
 
-    def test_record_callable_title(self):
-        """Check that callable titles are supported on objects."""
+    def test_omit_callable_title(self):
+        """It omits title attributes which are callable."""
         app = self.app
         obj = app.manage_addProduct['PageTemplates'].manage_addPageTemplate(
             id='test_pt', title='Not-visible', text='test text')
@@ -261,15 +261,11 @@ class TestSync():
         # Normal case
         result = zodbsync.mod_read(obj)
         assert 'Not-visible' in result['title']
-        assert 'Show-me' not in result['title']
-        assert 'test text' in result['source']
 
-        # with callable
+        # with callable title
         with mock.patch.object(obj, 'title', patch_title):
             result = zodbsync.mod_read(obj)
-            assert 'Not-visible' not in result['title']
-            assert 'Show-me' in result['title']
-            assert 'test text' in result['source']
+            assert 'title' not in result
 
     def test_playback(self):
         '''

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -73,6 +73,8 @@ def mod_read(obj=None, onerrorstop=False, default_owner=None,
 
     # The title should always be readable
     title = getattr(obj, 'title', None)
+    if callable(title):
+        title = title()
     # see comment in helpers.py:str_repr for why we convert to string
     meta['title'] = to_string(title)
 

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -75,10 +75,9 @@ def mod_read(obj=None, onerrorstop=False, default_owner=None,
 
     # The title should always be readable
     title = getattr(obj, 'title', None)
-    if callable(title):
-        title = title()
     # see comment in helpers.py:str_repr for why we convert to string
-    meta['title'] = to_string(title)
+    if isinstance(title, (six.binary_type, six.text_type)):
+        meta['title'] = to_string(title)
 
     # Generic and meta type dependent handlers
 


### PR DESCRIPTION
During the serialization of forms from `Products.Formulator`   an error occurred as in some cases the title of an object was a callable.