### PR TITLE
Add missing options use_tpc and datetime_str

### DIFF
--- a/perfact/zodbsync/object_types.py
+++ b/perfact/zodbsync/object_types.py
@@ -412,9 +412,9 @@ class ZPsycopgDAObj(ModObj):
         }
         # Place additional parameters into the object dict only if
         # they're set
-        if getattr(obj, 'use_tpc', False):
+        if hasattr(obj, 'use_tpc'):
             obj_dict['use_tpc'] = obj.use_tpc
-        if getattr(obj, 'datetime_str', False):
+        if hasattr(obj, 'datetime_str'):
             obj_dict['datetime_str'] = obj.datetime_str
         return obj_dict
 
@@ -429,10 +429,10 @@ class ZPsycopgDAObj(ModObj):
             'readonlymode': data.get('readonlymode', False),
             'encoding': data['encoding'],
         }
-        if data.get('use_tpc', False):
-            parameters['use_tpc'] = data['use_tpc']
-        if data.get('datetime_str', False):
-            parameters['datetime_str'] = data['datetime_str']
+        if hasattr(obj, 'use_tpc'):
+            parameters['use_tpc'] = data.get('use_tpc', False)
+        if hasattr(obj, 'datetime_str'):
+            parameters['datetime_str'] = data.get('datetime_str', False)
         obj.manage_edit(**parameters)
 
 

--- a/perfact/zodbsync/object_types.py
+++ b/perfact/zodbsync/object_types.py
@@ -409,6 +409,8 @@ class ZPsycopgDAObj(ModObj):
             'encoding': obj.encoding,
             'tilevel': obj.tilevel,
             'zdatetime': obj.zdatetime,
+            'use_tpc': getattr(obj, 'use_tpc', False),
+            'datetime_str': getattr(obj, 'datetime_str', False),
         }
 
     @staticmethod
@@ -418,9 +420,11 @@ class ZPsycopgDAObj(ModObj):
             connection_string=data['connection_string'],
             zdatetime=data['zdatetime'],
             tilevel=data['tilevel'],
-            autocommit=data['autocommit'],
-            readonlymode=data['readonlymode'],
+            autocommit=data.get('autocommit', False),
+            readonlymode=data.get('readonlymode', False),
             encoding=data['encoding'],
+            use_tpc=data.get('use_tpc', False),
+            datetime_str=data.get('datetime_str', False),
         )
 
 

--- a/perfact/zodbsync/object_types.py
+++ b/perfact/zodbsync/object_types.py
@@ -402,30 +402,38 @@ class ZPsycopgDAObj(ModObj):
     @staticmethod
     def read(obj):
         # late additions may not yet be everywhere in the Data.fs
-        return {
+        obj_dict = {
             'autocommit': getattr(obj, 'autocommit', False),
             'readonlymode': getattr(obj, 'readonlymode', False),
             'connection_string': obj.connection_string,
             'encoding': obj.encoding,
             'tilevel': obj.tilevel,
             'zdatetime': obj.zdatetime,
-            'use_tpc': getattr(obj, 'use_tpc', False),
-            'datetime_str': getattr(obj, 'datetime_str', False),
         }
+        # Place additional parameters into the object dict only if
+        # they're set
+        if getattr(obj, 'use_tpc', False):
+            obj_dict['use_tpc'] = obj.use_tpc
+        if getattr(obj, 'datetime_str', False):
+            obj_dict['datetime_str'] = obj.datetime_str
+        return obj_dict
 
     @staticmethod
     def write(obj, data):
-        obj.manage_edit(
-            title=data['title'],
-            connection_string=data['connection_string'],
-            zdatetime=data['zdatetime'],
-            tilevel=data['tilevel'],
-            autocommit=data.get('autocommit', False),
-            readonlymode=data.get('readonlymode', False),
-            encoding=data['encoding'],
-            use_tpc=data.get('use_tpc', False),
-            datetime_str=data.get('datetime_str', False),
-        )
+        parameters = {
+            'title': data['title'],
+            'connection_string': data['connection_string'],
+            'zdatetime':_data['zdatetime'],
+            'tilevel': data['tilevel'],
+            'autocommit': data.get('autocommit', False),
+            'readonlymode': data.get('readonlymode', False),
+            'encoding': data['encoding'],
+        }
+        if data.get('use_tpc', False):
+            parameters['use_tpc'] = data['use_tpc']
+        if data.get('datetime_str', False):
+            parameters['datetime_str'] = data['datetime_str']
+        obj.manage_edit(**parameters)
 
 
 class ZPyODBCDAObj(ModObj):

--- a/perfact/zodbsync/object_types.py
+++ b/perfact/zodbsync/object_types.py
@@ -411,10 +411,10 @@ class ZPsycopgDAObj(ModObj):
             'zdatetime': obj.zdatetime,
         }
         # Place additional parameters into the object dict only if
-        # they're set
-        if hasattr(obj, 'use_tpc'):
+        # they're set to non-default values
+        if hasattr(obj, 'use_tpc') and obj.use_tpc:
             obj_dict['use_tpc'] = obj.use_tpc
-        if hasattr(obj, 'datetime_str'):
+        if hasattr(obj, 'datetime_str') and obj.datetime_str:
             obj_dict['datetime_str'] = obj.datetime_str
         return obj_dict
 


### PR DESCRIPTION
If these options are missing, we record database connectors incompletely.