### PR TITLE
Add github-workflow to execute tox

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,44 @@
+name: Tox tests
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox
+  legacy:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.6']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,15 @@
 [tox]
 envlist = py2, py3
 
+[gh-actions]
+python =
+    3.6: py3
+    3.7: py3
+    3.8: py3
+    3.9: py3
+    3.10: py3
+    2.7: py2
+
 [testenv]
 deps =
     flake8


### PR DESCRIPTION
Adds a github-workflow to execute the tox-tests on PRs and pushes to "master". This currently excludes all tests performed for python 2.7 as this is no longer supported by the official github-actions and we would require a custom action to as implemented [here](https://github.com/LizardByte/.github/blob/nightly/actions/setup_python2/action.yml). 

Due to there possibly being breaking changes in the codebase of Zope or ZEO which may result in the tests failing (as it was actually the case with ZEO 5.4, but fixed in 5.4.1) we could also consider setting these tests up to also be executed on a schedule!

To see this in action you can take a look at the dummy-PR created on my [personal fork](https://github.com/Wiseqube/zodbsync/pull/1)