### PR TITLE
Refactor scripts into entry points to be usable with zc.buildout >= 3.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+???
+  * Refactor scripts into entry points to be usable with zc.buildout >= 3.
+
 22.1.0
   * Change versioning to include Ubuntu version the current template is based on
 

--- a/bin/perfact-zopeplayback
+++ b/bin/perfact-zopeplayback
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-assert False, (
-    "perfact-zopeplayback is no longer supported as executable, please use"
-    " zodbsync instead."
-)

--- a/bin/zodbsync
+++ b/bin/zodbsync
@@ -1,6 +1,0 @@
-#!/usr/bin/python
-
-from perfact.zodbsync.main import Runner
-
-if __name__ == '__main__':
-    Runner().run()

--- a/perfact/zodbsync/scripts.py
+++ b/perfact/zodbsync/scripts.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import argparse
 
 from perfact.zodbsync.main import Runner
@@ -9,12 +7,17 @@ try:
 except ImportError:
     pass
 
-if __name__ == '__main__':
+
+def zodbsync():
+    Runner().run()
+
+
+def zoperecord():
     parser = argparse.ArgumentParser(
         description='Record the Data.fs',
         epilog='''This script is deprecated in favor of zodbsync. Only bare
-        functionality is provided for backwards compatiblity with existing cron
-        entries.
+        functionality is provided for backwards compatibility with existing
+        cron entries.
         '''
     )
     parser.add_argument('--lasttxn', action='store_true', default=False,
@@ -44,3 +47,10 @@ if __name__ == '__main__':
         config.commit_message = msgbak
 
     runner.run()
+
+
+def zopeplayback():
+    assert False, (
+        "perfact-zopeplayback is no longer supported as executable, please use"
+        " zodbsync instead."
+    )

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,13 @@ setuptools.setup(
     packages=setuptools.find_packages('.'),
     package_data={
     },
-    scripts = [
-        'bin/perfact-zoperecord',
-        'bin/perfact-zopeplayback',
-        'bin/zodbsync',
-    ],
+    entry_points={
+        'console_scripts': [
+            'perfact-zoperecord=perfact.zodbsync.scripts:zoperecord',
+            'perfact-zopeplayback=perfact.zodbsync.scripts:zopeplayback',
+            'zodbsync=perfact.zodbsync.scripts:zodbsync',
+        ]
+    },
     license='GPLv2',
     platforms=['Linux',],
     install_requires=reqs,

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     git+https://github.com/perfact/Products.ZPyODBCDA
 
 commands = 
-    flake8 perfact bin
+    flake8 perfact
     coverage run --source=perfact,bin -m pytest {posargs}
     py2: coverage report --rcfile=.toxfiles/coveragerc-py2 --show-missing
     py3: coverage report --rcfile=.toxfiles/coveragerc-py3 --show-missing


### PR DESCRIPTION
`zc.buildout >=3` seems to ignore the `scripts` option in `setup.py`, so I refactored it into a entry-points which works successfully.