### PR TITLE
Drop support for Python 2

### DIFF
--- a/.toxfiles/coveragerc-py2
+++ b/.toxfiles/coveragerc-py2
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-  pragma: no cover
-  pragma: nocover_py2

--- a/.toxfiles/coveragerc-py3
+++ b/.toxfiles/coveragerc-py3
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-  pragma: no cover
-  pragma: nocover_py3

--- a/.toxfiles/reqs-py2.txt
+++ b/.toxfiles/reqs-py2.txt
@@ -1,3 +1,0 @@
-zope.mkzeoinstance==3.9.6
-Products.ZSQLMethods==2.13.6
-mock

--- a/.toxfiles/reqs-py3.txt
+++ b/.toxfiles/reqs-py3.txt
@@ -1,9 +1,0 @@
-# Requirements for tests with newest Zope
-zope.mkzeoinstance
-Products.StandardCacheManagers
-Products.ExternalMethod
-Products.MailHost
-Products.PythonScripts
-Products.StandardCacheManagers
-Products.SiteErrorLog
-Products.ZSQLMethods

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 unreleased
   * Omit title attributes if they are callable.
+  * Drop support for Python 2
 
 22.2.4
   * Refactor scripts into entry points to be usable with zc.buildout >= 3.

--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -1,17 +1,7 @@
 # -*- coding: utf-8 -*-
 import ast
 import operator
-import six
-
-if six.PY2:  # pragma: no cover
-    import imp
-    ast.Bytes = ast.Str
-
-    class DummyNameConstant:
-        pass
-    ast.NameConstant = DummyNameConstant
-else:  # pragma: no cover
-    import importlib
+import importlib
 
 
 class Namespace(object):
@@ -28,9 +18,7 @@ def to_string(value, enc='utf-8'):
     '''This method delivers bytes in python2 and unicode in python3.'''
     if isinstance(value, str):
         return value
-    if isinstance(value, six.text_type):  # pragma: nocover_py3
-        return value.encode(enc)
-    if isinstance(value, six.binary_type):  # pragma: nocover_py2
+    if isinstance(value, bytes):
         return value.decode(enc)
     return str(value)
 
@@ -38,9 +26,9 @@ def to_string(value, enc='utf-8'):
 def to_ustring(value, enc='utf-8'):
     '''Convert any string (bytes or unicode) into unicode.
     '''
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         return value
-    if isinstance(value, six.binary_type):
+    if isinstance(value, bytes):
         return value.decode(enc, 'ignore')
 
     return to_ustring(str(value))
@@ -50,9 +38,9 @@ def to_bytes(value, enc='utf-8'):
     '''This method delivers bytes (encoded strings).'''
     if isinstance(value, memoryview):
         return value.tobytes()
-    if isinstance(value, six.binary_type):
+    if isinstance(value, bytes):
         return value
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         return value.encode(enc)
     return to_bytes(str(value))
 
@@ -76,79 +64,6 @@ def remove_redundant_paths(paths):
     return paths
 
 
-# replacement mapping for str_repr
-repl = {chr(i): '\\x{:02x}'.format(i) for i in range(32)}
-# nicer formattings for some values
-repl.update({'\n': '\\n', '\r': '\\r', '\t': '\\t'})
-# make sure backslash is escaped first
-repl = [('\\', '\\\\')] + sorted(repl.items())
-
-
-def str_repr(val):
-    '''
-    Generic string representation of a value, used to serialize metadata.
-
-    This function is similar to repr(), giving a string representation of val
-    that can be stored to disk, read in again and fed into eval() in order to
-    regain the data. It supports basic data types (None, bool, int, float),
-    and strings (both bytes and unicode).
-
-    The most notable difference to repr() is the handling of strings. One of
-    the use cases of zodbsync is the transition of a ZODB from Python 2/Zope2
-    to Python 3/Zope4. Since simple string literals (like 'testü') mean
-    something different in Python 2 than in Python 3 (bytes in the first case,
-    unicode in the second), one might assume that the best representation would
-    be to always use explicit literals (b'testü' or u'testü'). However,
-    properties that were stored as bytes in Python 2 (like the titles of many
-    objects) usually have become unicode in Python3. In a default PerFact
-    installation, these properties were always *meant* to be UTF-8 encoded
-    text. So the best representation should store strings (i.e., bytes arrays
-    in Python 2 or unicode arrays in Python 3) without prefix and with as few
-    escapes as possible (so no \\xc3\\xbc, but simply ü), since this allows to
-    transfer the *meaning* rather than the *implementation details* from one
-    Python version to another ('testü' is a bytes array in Python2 containing
-    6 bytes that are meant to represent the given 5 characters, while it is a
-    unicode array in Python 3, stored in memory in some irrelevant manner).
-    The only characters being escaped are the unprintables (ASCII values 0-31),
-    the backslash and, if necessary, the quoting character.
-
-    This also ensures that recording metadata in Python 2, sending it through
-    2to3, playing it back in Python 3 and recording it again will a) restore
-    the correct meaning and b) create no diff for these properties in the 2to3
-    step or in the re-recording step - at least for properties that were bytes
-    in Python 2 and are unicode in Python 3.
-
-    Properties that were already unicode in Python2 do also exist. For these,
-    the recording would produce a literal like u'test\\xfc'. The 2to3 step
-    would remove the prefix, resulting in 'test\\xfc'. Playing the property
-    back to Python 3 would transport the correct value, but re-recording it
-    would produce 'testü'.
-
-    In order to remove both diffs, we encode all titles that are already
-    unicode in Python 2 to give bytes (see zodbsync.py:mod_read). They are
-    therefore recorded without a "u"-prefix and can be played back to both
-    Python 2 and Python 3, since setting a unicode title to a value that is
-    a bytes array automatically decodes the bytes array.
-    '''
-
-    if six.PY2 and isinstance(val, bytes):  # pragma: nocover_py3
-        # fall back to repr if val is not valid UTF-8
-        try:
-            val.decode('utf-8')
-        except UnicodeDecodeError:
-            return 'b' + repr(val)
-
-        for orig, r in repl:
-            val = val.replace(orig, r)
-
-        if ("'" in val) and not ('"' in val):
-            return '"%s"' % val
-        else:
-            return "'%s'" % val.replace("'", "\\'")
-    else:
-        return repr(val)
-
-
 class StrRepr:
     '''Create a printable output of the given object data.
     Dicts are converted to sorted lists of tuples, tuples and lists recurse
@@ -165,7 +80,7 @@ class StrRepr:
         "Internal recursion worker"
 
         if not isinstance(data, (list, tuple)):
-            self.output.append(str_repr(data))
+            self.output.append(repr(data))
             return
 
         # start new line for each element
@@ -217,65 +132,9 @@ class StrRepr:
         return ''.join(self.output) + '\n'
 
 
-def fix_encoding(data, encoding):  # pragma: nocover_py3
-    '''Assume that strings in 'data' are encoded in 'encoding' and change
-    them to unicode or utf-8.
-    Only python 2!
-    '''
-    assert six.PY2, "Not implemented for PY3 yet"
-    unpacked = dict(data)
-    if 'props' in unpacked:
-        unpacked_props = [dict(a) for a in unpacked['props']]
-        unpacked['props'] = unpacked_props
-
-    # Skip some types
-    skip_types = ['Image', ]
-    if unpacked['type'] in skip_types:
-        return data
-
-    # Check source
-    if 'source' in unpacked and isinstance(unpacked['source'], bytes):
-        # Only these types use ustrings, all others stay binary
-        ustring_types = [
-            # 'Page Template',
-            # 'Script (Python)',
-        ]
-        conversion = unpacked['source'].decode(encoding)
-        if unpacked['type'] not in ustring_types:
-            conversion = conversion.encode('utf-8')
-        unpacked['source'] = conversion
-
-    # Check title
-    if 'title' in unpacked and isinstance(unpacked['title'], bytes):
-        ustring_types = [
-            'Page Template',
-        ]
-        conversion = unpacked['title'].decode(encoding)
-        if unpacked['type'] not in ustring_types:
-            conversion = conversion.encode('utf-8')
-        unpacked['title'] = conversion
-
-    # Check string properties
-    if 'props' in unpacked:
-        for prop in unpacked['props']:
-            if prop['type'] == 'string':
-                prop['value'] = (
-                    str(prop['value']).decode(encoding).encode('utf-8')
-                )
-
-    if 'props' in unpacked:
-        repacked_props = []
-        for item in unpacked['props']:
-            pack = list(item.items())
-            pack.sort()
-            repacked_props.append(pack)
-        unpacked['props'] = repacked_props
-    return unpacked
-
-
 def read_pdata(obj):
     '''Avoid authentication problems when reading linked pdata.'''
-    if isinstance(obj.data, (six.binary_type, six.text_type)):
+    if isinstance(obj.data, (bytes, str)):
         source = obj.data
     else:
         data = obj.data
@@ -295,8 +154,7 @@ def literal_eval(value):
     This evaluator is capable of parsing large data sets, and it has
     basic arithmetic operators included.
     '''
-    _safe_names = {'None': None, 'True': True, 'False': False}
-    if isinstance(value, (six.binary_type, six.text_type)):
+    if isinstance(value, (bytes, str)):
         value = ast.parse(value, mode='eval')
 
     bin_ops = {
@@ -327,10 +185,7 @@ def literal_eval(value):
         elif isinstance(node, ast.Dict):
             return dict((_convert(k), _convert(v)) for k, v
                         in zip(node.keys, node.values))
-        elif isinstance(node, ast.Name):  # pragma: nocover_py3
-            if node.id in _safe_names:
-                return _safe_names[node.id]
-        elif isinstance(node, ast.NameConstant):  # pragma: nocover_py2
+        elif isinstance(node, ast.NameConstant):
             return node.value
         elif isinstance(node, ast.BinOp):
             return bin_ops[type(node.op)](
@@ -364,13 +219,10 @@ def load_config(filename, name='config'):
     '''Load the module at "filename" as module "name". Return the contents
     as a dictionary. Skips contents starting with '_'.
     '''
-    if six.PY2:  # pragma: nocover_py3
-        mod = imp.load_source(name, filename)
-    else:  # pragma: nocover_py2
-        loader = importlib.machinery.SourceFileLoader(name, filename)
-        spec = importlib.util.spec_from_loader(loader.name, loader)
-        mod = importlib.util.module_from_spec(spec)
-        loader.exec_module(mod)
+    loader = importlib.machinery.SourceFileLoader(name, filename)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
 
     return {
         name: getattr(mod, name)

--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -15,7 +15,7 @@ class Namespace(object):
 
 
 def to_string(value, enc='utf-8'):
-    '''This method delivers bytes in python2 and unicode in python3.'''
+    """Convert input into a string"""
     if isinstance(value, str):
         return value
     if isinstance(value, bytes):
@@ -23,19 +23,8 @@ def to_string(value, enc='utf-8'):
     return str(value)
 
 
-def to_ustring(value, enc='utf-8'):
-    '''Convert any string (bytes or unicode) into unicode.
-    '''
-    if isinstance(value, str):
-        return value
-    if isinstance(value, bytes):
-        return value.decode(enc, 'ignore')
-
-    return to_ustring(str(value))
-
-
 def to_bytes(value, enc='utf-8'):
-    '''This method delivers bytes (encoded strings).'''
+    """Convert input to bytes (encoded strings)"""
     if isinstance(value, memoryview):
         return value.tobytes()
     if isinstance(value, bytes):

--- a/perfact/zodbsync/tests/test_helpers.py
+++ b/perfact/zodbsync/tests/test_helpers.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 import pytest
 
 from .. import helpers
@@ -45,39 +44,6 @@ def test_converters():
     assert helpers.to_ustring([1]) == u'[1]'
     assert helpers.to_bytes([1]) == b'[1]'
     assert helpers.to_bytes(memoryview(b'test')) == b'test'
-
-
-def test_str_repr():
-    """
-    Check different inputs for str_repr against expected outputs
-    """
-    tests = [
-        ['äöüßáéí\n\r\t',
-         "'äöüßáéí\\n\\r\\t'"],
-
-        ['args="1, 2, 3"',
-         "'args=\"1, 2, 3\"'"],
-
-        [True, 'True'],
-
-        [45, '45'],
-
-        [34.5, '34.5'],
-
-        [('args', 'id=None, tn=False, streaming=True'),
-         "('args', 'id=None, tn=False, streaming=True')"],
-
-        ["'", '"' + "'" + '"'],  # "'"
-        ['"', "'" + '"' + "'"],  # '"'
-        ["'" + '"', "'\\'\"'"],  # '\'"'
-
-        # try a byte that is not valid UTF-8
-        [b'test\xaa', "b'test\\xaa'" if six.PY2 else u"b'test\\xaa'"],
-
-        [u'test\xaa', "u'test\\xaa'" if six.PY2 else u"'test\xaa'"],
-    ]
-    for orig, compare in tests:
-        assert helpers.str_repr(orig) == compare
 
 
 def test_StrRepr():
@@ -159,45 +125,3 @@ def test_literal_eval():
     assert helpers.literal_eval("-True") == -1
     with pytest.raises(Exception):
         helpers.literal_eval('f(1)')
-
-
-def test_fix_encoding():
-    example = {
-        'id': 'body',
-        'owner': 'jan',
-        'props': [
-            [('id', 'msg_deleted'), ('type', 'string'),
-             ('value', b'Datens\xe4tze gel\xf6scht!')],
-            [('id', 'content_type'), ('type', 'string'),
-             ('value', 'text/html')],
-            [('id', 'height'), ('type', 'int'), ('value', 20)],
-            [('id', 'expand'), ('type', 'boolean'), ('value', 1)]
-        ],
-        'source': (
-            b'<p>\nIm Bereich Limitplanung '
-            b'sind die Pl\xe4ne und Auswertungen '
-            b'zusammengefa\xdft.\n'
-        ),
-        'title': b'Werteplan Monats\xfcbersicht',
-        'type': 'DTML Method',
-    }
-    result = {
-        'id': 'body',
-        'owner': 'jan',
-        'props': [
-            [('id', 'msg_deleted'),
-             ('type', 'string'),
-             ('value', b'Datens\xc3\xa4tze gel\xc3\xb6scht!')],
-            [('id', 'content_type'), ('type', 'string'),
-             ('value', 'text/html')],
-            [('id', 'height'), ('type', 'int'), ('value', 20)],
-            [('id', 'expand'), ('type', 'boolean'), ('value', 1)]
-        ],
-        'source': (
-            b'<p>\nIm Bereich Limitplanung sind die Pl\xc3\xa4ne '
-            b'und Auswertungen zusammengefa\xc3\x9ft.\n'
-        ),
-        'title': b'Werteplan Monats\xc3\xbcbersicht',
-        'type': 'DTML Method',
-    }
-    assert six.PY3 or helpers.fix_encoding(example, 'iso-8859-1') == result

--- a/perfact/zodbsync/tests/test_helpers.py
+++ b/perfact/zodbsync/tests/test_helpers.py
@@ -36,12 +36,10 @@ def test_converters():
     """
     Several tests for to_* methods
     """
-    for value in ['test', b'test', u'test']:
+    for value in ['test', b'test']:
         assert helpers.to_bytes(value) == b'test'
         assert helpers.to_string(value) == 'test'
-        assert helpers.to_ustring(value) == u'test'
     assert helpers.to_string([1]) == '[1]'
-    assert helpers.to_ustring([1]) == u'[1]'
     assert helpers.to_bytes([1]) == b'[1]'
     assert helpers.to_bytes(memoryview(b'test')) == b'test'
 

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -2,7 +2,7 @@ import os
 import time
 import os.path
 import base64
-import six
+import io
 import json
 import subprocess
 import pickle
@@ -699,7 +699,7 @@ class TestSync():
         """
         watcher = self.mkrunner('watch')
         watcher.setup()
-        stream = six.BytesIO()
+        stream = io.BytesIO()
         watcher.dump_setup_data(stream=stream)
         data = pickle.loads(stream.getvalue())
         assert set(data.keys()) == {'tree', 'txn', 'add_oids'}

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -71,7 +71,7 @@ def mod_read(obj=None, onerrorstop=False, default_owner=None,
     # The title should always be readable
     title = getattr(obj, 'title', None)
     # see comment in helpers.py:str_repr for why we convert to string
-    if isinstance(title, (six.binary_type, six.text_type)):
+    if isinstance(title, (bytes, str)):
         meta['title'] = to_string(title)
 
     # Generic and meta type dependent handlers

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import sys
-
 import setuptools
 
-reqs = ['filelock']
-if sys.version_info.major == 2:
-    reqs.extend(['ZODB3', 'Zope2'])
-else:
-    reqs.extend(['ZODB', 'Zope'])
+reqs = ['filelock', 'ZODB', 'Zope']
 
 setuptools.setup(
     name='perfact-zodbsync',
@@ -28,6 +22,6 @@ setuptools.setup(
         ]
     },
     license='GPLv2',
-    platforms=['Linux',],
+    platforms=['Linux', ],
     install_requires=reqs,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py2, py3
+envlist = py3
 
 [gh-actions]
 python =
@@ -8,16 +8,20 @@ python =
     3.8: py3
     3.9: py3
     3.10: py3
-    2.7: py2
 
 [testenv]
 deps =
     flake8
     pytest 
     coverage
-    py2: -rhttps://raw.githubusercontent.com/zopefoundation/Zope/2.13.30/requirements.txt
-    py2: -r.toxfiles/reqs-py2.txt
-    py3: -r.toxfiles/reqs-py3.txt
+    zope.mkzeoinstance
+    Products.StandardCacheManagers
+    Products.ExternalMethod
+    Products.MailHost
+    Products.PythonScripts
+    Products.StandardCacheManagers
+    Products.SiteErrorLog
+    Products.ZSQLMethods
     psycopg2-binary
     git+https://github.com/perfact/ZPsycopgDA
     git+https://github.com/perfact/SimpleUserFolder
@@ -26,12 +30,4 @@ deps =
 commands = 
     flake8 perfact
     coverage run --source=perfact -m pytest {posargs}
-    py2: coverage report --rcfile=.toxfiles/coveragerc-py2 --show-missing
-    py3: coverage report --rcfile=.toxfiles/coveragerc-py3 --show-missing
-
-whitelist_externals =
-    py2: touch
-
-commands_pre =
-    # Somehow, this is needed on Ubuntu
-    py2: touch {envsitepackagesdir}/zope/__init__.py {envsitepackagesdir}/zc/__init__.py 
+    coverage report --show-missing


### PR DESCRIPTION
I think we can finally make this step. We still have systems with `perfact-dbutils-zope2` in the field, but the package has not received any updates since almost one year ago. At least on my current Ubuntu laptop, I have no way of testing if `zodbsync` still works with Python 2. I think with Archlinux it is still possible to execute the tests, but actually I don't think I want to check that.

If we find ourselves in some weird situation where we need to adjust the way `zodbsync` works for the migration of some old system that still wants to keep the decades old code base, the last release that was actually included in `perfact-dbutils-zope2`, namely 22.1.0, should serve as a starting point. I personally doubt that this will be the case.