### PR TITLE
Remove no longer existing bin dir from coverage config.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
 
 commands = 
     flake8 perfact
-    coverage run --source=perfact,bin -m pytest {posargs}
+    coverage run --source=perfact -m pytest {posargs}
     py2: coverage report --rcfile=.toxfiles/coveragerc-py2 --show-missing
     py3: coverage report --rcfile=.toxfiles/coveragerc-py3 --show-missing
 


### PR DESCRIPTION
It got removed in https://github.com/perfact/zodbsync/pull/115