### PR TITLE
Sync writes __source__ falsely into frozen layers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+23.1.3.dev0
+  * Fixed a bug where zodbsync was writing `source`-files into frozen
+    layers
+
 23.1.2
   * Add warning for custom layer paths shadowing changes in layer-update
   * Panic before deleting the top-level acl_users

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -2156,7 +2156,7 @@ class TestSync():
 
     def test_layer_frozen(self):
         """
-        Verify that changed files are propery written into the custom
+        Verify that changed files are properly written into the custom
         layer in case the layer below is frozen.
         """
         with self.runner.sync.tm:

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -2153,15 +2153,15 @@ class TestSync():
             assert expect + '/Test' in caplog.text
             assert 'AttributeError' not in caplog.text
             assert expect + '/ToDelete/Sub' in caplog.text
-    
+
     def test_layer_frozen(self):
         """
         Verify that changed files are propery written into the custom
         layer in case the layer below is frozen.
         """
         with self.runner.sync.tm:
-            self.app.manage_addProduct['OFSP'].manage_addFile(id='blob') 
-        
+            self.app.manage_addProduct['OFSP'].manage_addFile(id='blob')
+
         with self.addlayer(frozen=True) as layer:
             self.run('record', '/blob')
             shutil.move(

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -2179,6 +2179,10 @@ class TestSync():
             # both meta and source file are in custom layer
             assert os.path.exists(os.path.join(root, 'blob/__meta__'))
             assert os.path.exists(os.path.join(root, 'blob/__source__.txt'))
-            with open('{}/__root__/blob/__source__.txt'.format(layer)) as f:
+            source_fmt = '{}/__root__/blob/__source__.txt'
+            with open(source_fmt.format(layer)) as f:
                 # source in layer should still be empty
                 assert f.read() == ''
+            with open(source_fmt.format(self.repo.path)) as f:
+                # ... content is in custom layer!
+                assert f.read() == 'text_content'

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -470,7 +470,6 @@ class ZODBSync:
                 obj_id=path.rstrip('/').rsplit('/', 1)[-1],
             )
             src_fname = '{}.{}'.format(base, ext)
-            src_path = os.path.join(base_dir, src_fname)
             new_data['src_fnames'] = [src_fname]
             new_data['source'] = source
 
@@ -494,7 +493,7 @@ class ZODBSync:
                 self.logger.debug(
                     "Will write %d bytes of source" % len(source)
                 )
-                with open(src_path, 'wb') as f:
+                with open(os.path.join(write_base, src_fname), 'wb') as f:
                     f.write(source)
 
             # We wrote the object to the topmost layer, so the index where the


### PR DESCRIPTION
This PR fixes an issue where zodbsync was overwriting the contents of a source-file in a frozen layer. 

The test-case is as follows:
1. We record an object into the custom layer
2. The filesystem objects are moved to the frozen layer manually
3. The content in the Data.FS is modified, in this case we edith both the meta aswell as the content data
4. A record is executed. 

The expected behaviour would be that the changed meta and source files are both written into the custom-layer. The actual behaviour is that the `__meta__`-File is correctly written into the custom-layer but the `__source__`-File is modified in the frozen layer below!

The issue was that the path which was generated for the source-file was based on the layer-path while the path for the meta-file was generated based upon the custom upper layer!