### PR TITLE
Write layer-source of object into Data.FS

### DIFF
--- a/perfact/zodbsync/commands/watch.py
+++ b/perfact/zodbsync/commands/watch.py
@@ -187,7 +187,13 @@ class Watch(SubCommand):
             obj=obj,
             default_owner=self.sync.default_owner
         )
-        self.sync.fs_write(path=path, data=data)
+
+        pathinfo = self.sync.fs_write(path=path, data=data)
+        path_layer = pathinfo['layers'][pathinfo['layeridx']]['ident']
+        current_layer = getattr(obj, 'zodbsync_layer', None)
+        if current_layer != path_layer:
+            with self.sync.tm:
+                obj.zodbsync_layer = path_layer
 
     def _update_objects(self):
         '''

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -1994,8 +1994,7 @@ class TestSync():
                 os.path.join(root, 'Test'),
                 os.path.join(layer, 'workdir/__root__/Test'),
             )
-            with self.runner.sync.tm:
-                self.app.Test.manage_delObjects(ids=['Sub'])
+            self.app.Test.manage_delObjects(ids=['Sub'])
             self.run('record', '/')
             assert not os.path.exists(os.path.join(root, 'Test/__meta__'))
             assert not os.path.exists(os.path.join(root, 'Test/Sub/__meta__'))
@@ -2299,8 +2298,7 @@ class TestSync():
                 '{}/__root__/blob'.format(layer),
             )
             self.run('record', '/')
-            with self.runner.sync.tm:
-                assert getattr(self.app.blob, 'zodbsync_layer') is not None
+            assert getattr(self.app.blob, 'zodbsync_layer') is not None
             # Change file in Data.FS and verify that layer info is cleared
             with self.runner.sync.tm:
                 self.app.blob.manage_edit(

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -2293,13 +2293,13 @@ class TestSync():
         with self.runner.sync.tm:
             self.app.manage_addProduct['OFSP'].manage_addFile(id='blob')
 
-        with self.addlayer(frozen=True) as layer:
+        with self.addlayer() as layer:
             self.run('record', '/blob')
             assert getattr(self.app.blob, 'zodbsync_layer', None) is None
             # Move file to layer and check that layer info is stored in Data.FS
             shutil.move(
                 '{}/__root__/blob'.format(self.repo.path),
-                '{}/__root__/blob'.format(layer),
+                '{}/workdir/__root__/blob'.format(layer),
             )
             self.run('record', '/')
             assert getattr(self.app.blob, 'zodbsync_layer') is not None

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -1994,7 +1994,8 @@ class TestSync():
                 os.path.join(root, 'Test'),
                 os.path.join(layer, 'workdir/__root__/Test'),
             )
-            self.app.Test.manage_delObjects(ids=['Sub'])
+            with self.runner.sync.tm:
+                self.app.Test.manage_delObjects(ids=['Sub'])
             self.run('record', '/')
             assert not os.path.exists(os.path.join(root, 'Test/__meta__'))
             assert not os.path.exists(os.path.join(root, 'Test/Sub/__meta__'))

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -2290,6 +2290,9 @@ class TestSync():
         Validate the correct writing and clearing of the layer ident
         in the Data.FS
         """
+        with self.runner.sync.tm:
+            self.app.manage_addProduct['OFSP'].manage_addFile(id='blob')
+
         with self.addlayer(frozen=True) as layer:
             self.run('record', '/blob')
             assert getattr(self.app.blob, 'zodbsync_layer', None) is None

--- a/perfact/zodbsync/tests/test_sync.py
+++ b/perfact/zodbsync/tests/test_sync.py
@@ -2192,6 +2192,9 @@ class TestSync():
         the top layer. Check that the playback hook script gets the normalized
         object paths and not the specific files.
         """
+        with self.runner.sync.tm:
+            self.app.manage_addProduct['OFSP'].manage_addFile(id='blob')
+
         root = '{}/__root__'.format(self.repo.path)
         with self.addlayer() as layer:
             self.run('record', '/blob')
@@ -2287,9 +2290,6 @@ class TestSync():
         Validate the correct writing and clearing of the layer ident
         in the Data.FS
         """
-        with self.runner.sync.tm:
-            self.app.manage_addProduct['OFSP'].manage_addFile(id='blob')
-
         with self.addlayer(frozen=True) as layer:
             self.run('record', '/blob')
             assert getattr(self.app.blob, 'zodbsync_layer', None) is None

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -754,8 +754,9 @@ class ZODBSync:
         fs_data = pathinfo['fspath'] and self.fs_parse(pathinfo['fspath'])
 
         # extend fs_data with layerinfo
-        fs_data['zodbsync_layer'] = pathinfo['layers'][
-            pathinfo['layeridx']]['ident']
+        if fs_data:
+            fs_data['zodbsync_layer'] = pathinfo['layers'][
+                pathinfo['layeridx']]['ident']
 
         # Traverse to the object if it exists
         parent_obj = None

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -691,6 +691,12 @@ class ZODBSync:
                 raise
 
         pathinfo = self.fs_write(path, data)
+        path_layer = pathinfo['layers'][pathinfo['layeridx']]['ident']
+
+        current_layer = getattr(obj, 'zodbsync_layer', None)
+        if current_layer != path_layer:
+            with self.tm:
+                obj.zodbsync_layer = path_layer
 
         if not recurse:
             return

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -695,8 +695,7 @@ class ZODBSync:
 
         current_layer = getattr(obj, 'zodbsync_layer', None)
         if current_layer != path_layer:
-            with self.tm:
-                obj.zodbsync_layer = path_layer
+            obj.zodbsync_layer = path_layer
 
         if not recurse:
             return

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -466,7 +466,7 @@ class ZODBSync:
         old_data = self.fs_read(pathinfo['fspath'])
 
         # Build object
-        exclude_keys = ['source', 'zodbsync_layer']
+        exclude_keys = ['source', 'zodbsync_layer', 'is_root']
         meta = {
             key: value
             for key, value in data.items()
@@ -695,7 +695,8 @@ class ZODBSync:
 
         current_layer = getattr(obj, 'zodbsync_layer', None)
         if current_layer != path_layer:
-            obj.zodbsync_layer = path_layer
+            with self.tm:
+                obj.zodbsync_layer = path_layer
 
         if not recurse:
             return

--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -94,11 +94,13 @@ def mod_read(obj=None, onerrorstop=False, default_owner=None,
         if 'owner' in meta:
             del meta['owner']
 
+    meta['zodbsync_layer'] = getattr(obj, 'zodbsync_layer', None)
+
     return meta
 
 
 def mod_write(data, parent=None, obj_id=None, override=False, root=None,
-              default_owner=None, force_default_owner=False):
+              default_owner=None, force_default_owner=False, layer=None):
     '''
     Given object data in <data>, store the object, creating it if it was
     missing. With <override> = True, this method will remove an existing object
@@ -162,6 +164,9 @@ def mod_write(data, parent=None, obj_id=None, override=False, root=None,
     # Send an update (depending on type)
     for handler in mod_implemented_handlers(obj, meta_type):
         handler.write(obj, d)
+
+    # Also write zodbsync layer information
+    obj.zodbsync_layer = layer
 
     if temp_obj:
         children = temp_obj.manage_cutObjects(temp_obj.objectIds())
@@ -461,7 +466,12 @@ class ZODBSync:
         old_data = self.fs_read(pathinfo['fspath'])
 
         # Build object
-        meta = {key: value for key, value in data.items() if key != 'source'}
+        exclude_keys = ['source', 'zodbsync_layer']
+        meta = {
+            key: value
+            for key, value in data.items()
+            if key not in exclude_keys
+        }
         fmt = mod_format(meta)
         if isinstance(fmt, str):
             fmt = fmt.encode('utf-8')
@@ -743,6 +753,10 @@ class ZODBSync:
         # fspath is None if the object is to be deleted
         fs_data = pathinfo['fspath'] and self.fs_parse(pathinfo['fspath'])
 
+        # extend fs_data with layerinfo
+        fs_data['zodbsync_layer'] = pathinfo['layers'][
+            pathinfo['layeridx']]['ident']
+
         # Traverse to the object if it exists
         parent_obj = None
         obj = self.app
@@ -827,6 +841,7 @@ class ZODBSync:
                     root=(obj if parent_obj is None else None),
                     default_owner=self.default_owner,
                     force_default_owner=self.force_default_owner,
+                    layer=pathinfo['layers'][pathinfo['layeridx']]['ident']
                 )
             except Exception:
                 # If we do not want to get errors from missing


### PR DESCRIPTION
Well, does what is says on the tin (atleast proof of concept wise)! Basically I had the idea that the Data.FS should just know from which layer an object was uploaded so we can make use of this information inside of the application (for example the ZMI). For this we just store the layer-ident in the `zodbsync_layer` property of an object (not the PropertySheet functionality, but just actual python properties), which are just as happily written into the Data.FS!

Whats currently missing is the "update" of this property in case the file is changed in Zope and therefor changes it`s source-layer! But I wanted to wait to implement something for this until I got feedback on whether this is actually something we would like to pursue further. 

For testing purposes I actually patched the ZMI to display the layer-ident, which is really working like a charm:

```diff
diff --git a/src/OFS/zpt/main.zpt b/src/OFS/zpt/main.zpt
index e3d4c814b..83543f89a 100644
--- a/src/OFS/zpt/main.zpt
+++ b/src/OFS/zpt/main.zpt
@@ -91,6 +91,9 @@
                   <span class="zmi-object-title hidden-xs" tal:condition="ob/title|nothing">
                     &nbsp;(<span tal:replace="ob/title"></span>)
                   </span>
+                  <span class="zmi-object-title hidden-xs" tal:condition="ob/zodbsync_layer|nothing">
+                    &nbsp;(<span tal:replace="ob/zodbsync_layer"></span>)
+                  </span>
                 </a>
               </td>
               <td class="text-right zmi-object-size hidden-xs" tal:content="python:here.compute_size(ob)">
```