### PR TITLE
Only try to playback paths below __root__

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+23.2.1.dev0
+  * Only try to playback differing paths below __root__
+
 23.2.0
   * Fixed a bug where zodbsync was writing `source`-files into frozen
     layers

--- a/perfact/zodbsync/subcommand.py
+++ b/perfact/zodbsync/subcommand.py
@@ -246,7 +246,9 @@ class SubCommand(Namespace):
                 assert not conflicts, "Change in unstaged files, aborting"
 
                 # Make unique and sort
-                self.paths = sorted(set(files))
+                self.paths = sorted({
+                    file for file in files if file.startswith(self.sync.site)
+                })
 
                 self._playback_paths(self.paths)
 


### PR DESCRIPTION
Mostly a cosmetic issue, I was wondering about the output of
```
ZODBSync INFO Using user perfact
ZODBSync INFO Uploading .gitignore/
ZODBSync INFO Uploading README.md/
ZODBSync INFO Uploading debian/changelog/
ZODBSync INFO Uploading debian/control/
ZODBSync INFO Uploading debian/rules/
ZODBSync INFO Uploading debian/source/format/
ZODBSync INFO Uploading extract-checksums/
```
during a `zodbsync reset` on a system where a debianized layer package is still checked out.