### PR TITLE
T282763: Make zodbsync record output more specific

### DIFF
--- a/perfact/zodbsync/zodbsync.py
+++ b/perfact/zodbsync/zodbsync.py
@@ -550,9 +550,9 @@ class ZODBSync:
         for item in pathinfo['children']:
             if item in contents:
                 continue
-            self.logger.info("Removing old item %s from filesystem" % item)
             tgt = os.path.join(base_dir, item)
             if os.path.isdir(tgt):
+                self.logger.info("Removing old item %s from filesystem" % item)
                 shutil.rmtree(tgt)
             meta = os.path.join(relpath, item, '__meta__')
             # Omit topmost (custom) layer


### PR DESCRIPTION
On a layers system this logger line is always displayed for missing files. This PR moves the log line right next to the deletion to ensure the output is more concise with what is deleted.