### PR TITLE
Add test for reset removing deleted marker

### DIFF
--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -161,12 +161,8 @@ def literal_eval(value):
     def _convert(node):
         if isinstance(node, ast.Expression):
             return _convert(node.body)
-        elif isinstance(node, ast.Str):
-            return node.s
-        elif isinstance(node, ast.Bytes):  # pragma: nocover_py2
-            return node.s
-        elif isinstance(node, ast.Num):
-            return node.n
+        elif isinstance(node, ast.Constant):
+            return node.value
         elif isinstance(node, ast.Tuple):
             return tuple(map(_convert, node.elts))
         elif isinstance(node, ast.List):
@@ -174,8 +170,6 @@ def literal_eval(value):
         elif isinstance(node, ast.Dict):
             return dict((_convert(k), _convert(v)) for k, v
                         in zip(node.keys, node.values))
-        elif isinstance(node, ast.NameConstant):
-            return node.value
         elif isinstance(node, ast.BinOp):
             return bin_ops[type(node.op)](
                 _convert(node.left),


### PR DESCRIPTION
A first try to reproduce the error that I sometimes encountered. The problem seems to be twofold:
- Sometimes, a `layer-update` will not actually play back all new paths, so the paths that are not played back but are present in the lower layer, so a `__deleted__` marker is added to the top layer. At least in some cases this seems to be related to the two-phase playback: A path `something/Development/file` is to be added in the first phase due to containing `Development`, so `something` is also created in the first phase, then it is also added in the second phase, but all new subobjects of `something` that are to be added in the second phase are not actually played back.
- When a record with `--autoreset` tries to fix the `Data.FS` so it is forced to represent the same state as given in the layers, the `__deleted__` markers are removed, but this is does not recreate the objects.

I tried to write a test for the second part, but it works as expected.

It is possible that the error is already fixed with the recent release where I refactored some layer handling, so this becomes unnecessary. But maybe I'm still missing something.