### PR TITLE
T285630: Remove logging from signal handler

### DIFF
--- a/perfact/zodbsync/commands/watch.py
+++ b/perfact/zodbsync/commands/watch.py
@@ -437,3 +437,5 @@ class Watch(SubCommand):
             self.step()
             # a wait that is interrupted immediately if exit.set() is called
             self.exit.wait(interval)
+
+        self.logger.info('Exited due to signal')


### PR DESCRIPTION
@viktordick:
Hi Viktor,
We’ve encountered a reentrant error on the Froneri systems related to this package. The issue occurs because logger.info is used inside a signal handler.
If an ongoing I/O call is interrupted by a signal, it can result in two simultaneous calls to the I/O stack, which triggers the error.

Relevant links:
- https://bugs.python.org/issue24283
- Ticket with issue description - Follow-Up Ticket: Routinecheck - zodbsync3 Logging error - T285630