### PR TITLE
Do not use tar --recursive-unlink when unpacking layer sources

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+  * Clear target ourselves instead of using tar --recursive-unlink, which
+    fails on tar < 1.35 if the tarball contains "."
+
 26.4.0
   * Expose helper function for extracting layer config
 

--- a/perfact/zodbsync/subcommand.py
+++ b/perfact/zodbsync/subcommand.py
@@ -130,6 +130,11 @@ class SubCommand(Namespace):
                 # p.e. __root__.tar.gz -> Unpack to __root__/
                 basename = entry.split(".")[0]
                 targetitems.append(basename)
+                # Clear the target ourselves instead of using
+                # --recursive-unlink, which fails with
+                # "tar: .: Cannot unlink: Invalid argument" if the tarball
+                # contains "." as member (tar < 1.35, e.g. Ubuntu 22.04).
+                shutil.rmtree(f"{tgt}/{basename}", ignore_errors=True)
                 os.makedirs(f"{tgt}/{basename}", exist_ok=True)
                 cmd = [
                     "tar",
@@ -137,7 +142,6 @@ class SubCommand(Namespace):
                     path,
                     "-C",
                     f"{tgt}/{basename}/",
-                    "--recursive-unlink",
                     "-m",
                 ]
             subprocess.run(cmd, check=True)


### PR DESCRIPTION
GNU tar before 1.35 (e.g. Ubuntu 22.04) tries to remove the extraction root itself if the tarball contains "." as a member, which fails with

    tar: .: Cannot unlink: Invalid argument

and makes the whole layer-init/layer-update run fail. Clear the target directory in Python instead. This is equivalent: --recursive-unlink emptied the same hierarchy, and tar rewrites every member on extraction in any case, so no additional disk load.