### PR TITLE
Only write layer files whose content actually changed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+  * Unpack layer tarballs in Python, only writing files whose content actually
+    changed, so unchanged files keep their mtime
+  * Apply the permissions from layer tarballs exactly, keeping the setgid bit
+    of directories instead of masking everything with the umask
   * Clear target ourselves instead of using tar --recursive-unlink, which
     fails on tar < 1.35 if the tarball contains "."
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+  * Clear target ourselves instead of using tar --recursive-unlink, which
+    fails on tar < 1.35 if the tarball contains "."
+
 26.4.0
   * Expose helper function for extracting layer config
 

--- a/perfact/zodbsync/helpers.py
+++ b/perfact/zodbsync/helpers.py
@@ -3,6 +3,12 @@ import ast
 import importlib
 import operator
 import os
+import shutil
+import tarfile
+
+# Members larger than this are written without comparing them to the existing
+# file first, so we never hold an arbitrary amount of data in memory.
+UNPACK_COMPARE_LIMIT = 16 * 1024 * 1024
 
 
 class Namespace(object):
@@ -272,6 +278,149 @@ def path_diff(old, new):
     result.update([row[0] for row in old[oldidx:]])
     result.update([row[0] for row in new[newidx:]])
     return result
+
+
+def _is_dir(path):
+    """Check for a real directory, not a symlink pointing to one."""
+    return os.path.isdir(path) and not os.path.islink(path)
+
+
+def _remove(path):
+    """Remove path, no matter if it is a file, symlink or directory."""
+    if _is_dir(path):
+        shutil.rmtree(path)
+    elif os.path.lexists(path):
+        os.remove(path)
+
+
+def _prepare_parents(target, name):
+    """
+    Make sure each element of the parent path of name is a real directory below
+    target, replacing anything that is in the way. Doing this per member means
+    the archive does not have to be ordered such that a directory is listed
+    before its content.
+    """
+    parts = name.split("/")
+    for idx in range(1, len(parts)):
+        path = os.path.join(target, *parts[:idx])
+        if os.path.lexists(path) and not _is_dir(path):
+            os.remove(path)
+        if not os.path.exists(path):
+            os.mkdir(path)
+
+
+def _set_mode(path, member):
+    """
+    Apply the permissions of member to path. This is done explicitly instead of
+    relying on the mode given to mkdir or open, which is subject to the umask
+    and would drop the setgid bit and the group write permission that make the
+    resulting repository a group repository.
+    """
+    mode = member.mode & 0o7777
+    if os.stat(path).st_mode & 0o7777 != mode:
+        os.chmod(path, mode)
+
+
+def _matches(path, data):
+    """Check if the file at path holds exactly data."""
+    try:
+        if os.path.getsize(path) != len(data):
+            return False
+        with open(path, "rb") as fh:
+            return fh.read() == data
+    except OSError:
+        return False
+
+
+def _unpack_file(tar, member, path):
+    """
+    Make sure path holds the content of member, leaving it untouched if it
+    already does.
+    """
+    with tar.extractfile(member) as src:
+        if member.size <= UNPACK_COMPARE_LIMIT:
+            data = src.read()
+            if not _matches(path, data):
+                _remove(path)
+                with open(path, "wb") as fh:
+                    fh.write(data)
+        else:
+            _remove(path)
+            with open(path, "wb") as fh:
+                shutil.copyfileobj(src, fh)
+
+    _set_mode(path, member)
+
+
+def _unpack_symlink(member, path):
+    """Make sure path is a symlink pointing where member says."""
+    if os.path.islink(path) and os.readlink(path) == member.linkname:
+        return
+    _remove(path)
+    os.symlink(member.linkname, path)
+
+
+def unpack_tar(archive, target):
+    """
+    Unpack archive into target, which is created if it does not exist yet.
+
+    Files that already hold the correct content are not written again, so their
+    mtime is kept and git does not have to rehash them. Everything in target
+    that is not part of the archive is removed afterwards. Timestamps from the
+    archive are never applied (as with tar -m), permissions always are (as with
+    tar -p), including those of the extraction root itself if the archive
+    contains it as "." - the sources are built with setgid directories to yield
+    a group repository.
+
+    Each member must occur only once in the archive. The order of members is
+    irrelevant.
+    """
+    os.makedirs(target, exist_ok=True)
+    seen = set()
+
+    with tarfile.open(archive) as tar:
+        for member in tar:
+            name = os.path.normpath(member.name)
+            if name.startswith(("/", "..")):
+                # Something outside of the extraction root
+                continue
+            if name == ".":
+                # The extraction root itself, which only carries permissions
+                _set_mode(target, member)
+                continue
+            seen.add(name)
+            path = os.path.join(target, name)
+            _prepare_parents(target, name)
+
+            if member.isdir():
+                if not _is_dir(path):
+                    _remove(path)
+                    os.mkdir(path)
+                _set_mode(path, member)
+            elif member.issym():
+                _unpack_symlink(member, path)
+            elif member.isfile():
+                _unpack_file(tar, member, path)
+            else:
+                # Hardlinks, devices etc. are not expected, but let's not lose
+                # them if they do show up.
+                _remove(path)
+                tar.extract(member, target, set_attrs=False)
+
+    # Parent directories are to be kept even if the archive does not list them
+    # explicitly.
+    for name in list(seen):
+        while "/" in name:
+            name = name.rsplit("/", 1)[0]
+            seen.add(name)
+
+    # Walking bottom-up means any directory we are about to remove has already
+    # been emptied of everything that is not in the archive.
+    for root, dirs, files in os.walk(target, topdown=False):
+        for entry in dirs + files:
+            path = os.path.join(root, entry)
+            if os.path.relpath(path, target) not in seen:
+                _remove(path)
 
 
 def load_layer_config(config=None, path=None):

--- a/perfact/zodbsync/subcommand.py
+++ b/perfact/zodbsync/subcommand.py
@@ -8,7 +8,7 @@ import sys
 
 import filelock
 
-from .helpers import Namespace
+from .helpers import Namespace, unpack_tar
 
 
 class SubCommand(Namespace):
@@ -126,25 +126,12 @@ class SubCommand(Namespace):
                     continue
                 targetitems.append(entry)
                 cmd = ["rsync", "-a", "--delete-during", f"{path}/", f"{tgt}/{entry}/"]
+                subprocess.run(cmd, check=True)
             else:
                 # p.e. __root__.tar.gz -> Unpack to __root__/
                 basename = entry.split(".")[0]
                 targetitems.append(basename)
-                # Clear the target ourselves instead of using
-                # --recursive-unlink, which fails with
-                # "tar: .: Cannot unlink: Invalid argument" if the tarball
-                # contains "." as member (tar < 1.35, e.g. Ubuntu 22.04).
-                shutil.rmtree(f"{tgt}/{basename}", ignore_errors=True)
-                os.makedirs(f"{tgt}/{basename}", exist_ok=True)
-                cmd = [
-                    "tar",
-                    "xf",
-                    path,
-                    "-C",
-                    f"{tgt}/{basename}/",
-                    "-m",
-                ]
-            subprocess.run(cmd, check=True)
+                unpack_tar(path, f"{tgt}/{basename}")
         for entry in os.listdir(tgt):
             if entry.startswith(".") or entry in targetitems:
                 continue

--- a/perfact/zodbsync/subcommand.py
+++ b/perfact/zodbsync/subcommand.py
@@ -130,6 +130,11 @@ class SubCommand(Namespace):
                 # p.e. __root__.tar.gz -> Unpack to __root__/
                 basename = entry.split(".")[0]
                 targetitems.append(basename)
+                # Clear the target ourselves instead of using
+                # --recursive-unlink, which fails with
+                # "tar: .: Cannot unlink: Invalid argument" if the tarball
+                # contains "." as member (tar < 1.35, e.g. Ubuntu 22.04).
+                shutil.rmtree(f"{tgt}/{basename}", ignore_errors=True)
                 os.makedirs(f"{tgt}/{basename}", exist_ok=True)
                 cmd = [
                     "tar",
@@ -137,7 +142,6 @@ class SubCommand(Namespace):
                     path,
                     "-C",
                     f"{tgt}/{basename}/",
-                    "--recursive-unlink",
                     "-m",
                 ]
             subprocess.run(cmd, check=True)

--- a/perfact/zodbsync/tests/test_helpers.py
+++ b/perfact/zodbsync/tests/test_helpers.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import io
+import os
+import tarfile
+
 import pytest
 
 from .. import helpers
@@ -146,3 +150,119 @@ def test_path_diff():
     ]
     result = helpers.path_diff(old, new)
     assert result == {"Def", "Xyz", "Yyy"}
+
+
+def build_tar(path, members, dirmode=0o755, filemode=0o644):
+    """
+    Create a tarball, where members maps the name inside the archive to the
+    content of the file, using None for a directory. Members are added in the
+    given order.
+    """
+    with tarfile.open(path, "w:gz") as tar:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name)
+            if content is None:
+                info.type = tarfile.DIRTYPE
+                info.mode = dirmode
+                tar.addfile(info)
+                continue
+            data = content.encode("utf-8")
+            info.size = len(data)
+            info.mode = filemode
+            tar.addfile(info, io.BytesIO(data))
+
+
+def read_tree(path):
+    """
+    Return a dict mapping each path below path to the content of the file,
+    using None for a directory.
+    """
+    result = {}
+    for root, dirs, files in os.walk(path):
+        for entry in dirs:
+            result[os.path.relpath(f"{root}/{entry}", path)] = None
+        for entry in files:
+            with open(f"{root}/{entry}") as fh:
+                result[os.path.relpath(f"{root}/{entry}", path)] = fh.read()
+    return result
+
+
+def test_unpack_tar(tmp_path):
+    """
+    Check that an archive is unpacked correctly, that superfluous elements in
+    the target are removed and that files which are already correct are not
+    written again.
+    """
+    archive = str(tmp_path / "a.tar.gz")
+    target = str(tmp_path / "tgt")
+    content = {".": None, "./sub": None, "./sub/a.txt": "A", "./b.txt": "B"}
+    build_tar(archive, content)
+    helpers.unpack_tar(archive, target)
+    assert read_tree(target) == {"sub": None, "sub/a.txt": "A", "b.txt": "B"}
+
+    # Superfluous file, directory and content that is no longer part of the
+    # archive
+    os.makedirs(f"{target}/stale/deeper")
+    with open(f"{target}/stale/deeper/x.txt", "w") as fh:
+        fh.write("x")
+    with open(f"{target}/sub/extra.txt", "w") as fh:
+        fh.write("x")
+    unchanged = os.stat(f"{target}/sub/a.txt").st_mtime_ns
+
+    content["./b.txt"] = "B2"
+    build_tar(archive, content)
+    helpers.unpack_tar(archive, target)
+    assert read_tree(target) == {"sub": None, "sub/a.txt": "A", "b.txt": "B2"}
+    assert os.stat(f"{target}/sub/a.txt").st_mtime_ns == unchanged
+
+
+def test_unpack_tar_unordered(tmp_path):
+    """
+    Check that a directory may be listed after its own content and that it
+    replaces a file that is currently in the way, and vice versa.
+    """
+    archive = str(tmp_path / "a.tar.gz")
+    target = str(tmp_path / "tgt")
+    os.makedirs(target)
+    with open(f"{target}/x", "w") as fh:
+        fh.write("in the way")
+
+    build_tar(archive, {"z.txt": "Z", "x/y.txt": "Y", "x": None})
+    helpers.unpack_tar(archive, target)
+    assert read_tree(target) == {"x": None, "x/y.txt": "Y", "z.txt": "Z"}
+
+    build_tar(archive, {"z.txt": "Z", "x": "now a file"})
+    helpers.unpack_tar(archive, target)
+    assert read_tree(target) == {"x": "now a file", "z.txt": "Z"}
+
+
+def test_unpack_tar_modes(tmp_path):
+    """
+    Check that the permissions of the archive are applied regardless of the
+    umask, including the setgid bit and the permissions of the extraction root
+    itself, which the sources use to yield a group repository.
+    """
+    archive = str(tmp_path / "a.tar.gz")
+    target = str(tmp_path / "tgt")
+    content = {".": None, "./sub": None, "./sub/a.txt": "A"}
+    build_tar(archive, content, dirmode=0o2775, filemode=0o664)
+
+    orig_umask = os.umask(0o022)
+    try:
+        helpers.unpack_tar(archive, target)
+        modes = {
+            path: os.stat(f"{target}/{path}").st_mode & 0o7777
+            for path in [".", "sub", "sub/a.txt"]
+        }
+        assert modes == {".": 0o2775, "sub": 0o2775, "sub/a.txt": 0o664}
+
+        # A mode-only change is corrected as well, without rewriting the file
+        os.chmod(f"{target}/sub", 0o755)
+        os.chmod(f"{target}/sub/a.txt", 0o644)
+        unchanged = os.stat(f"{target}/sub/a.txt").st_mtime_ns
+        helpers.unpack_tar(archive, target)
+        assert os.stat(f"{target}/sub").st_mode & 0o7777 == 0o2775
+        assert os.stat(f"{target}/sub/a.txt").st_mode & 0o7777 == 0o664
+        assert os.stat(f"{target}/sub/a.txt").st_mtime_ns == unchanged
+    finally:
+        os.umask(orig_umask)


### PR DESCRIPTION
Unpacking a layer source rewrote every file in the tarball, even if only
a handful of them changed. With a layer of several hundred MB that is a
lot of needless disk traffic, and since the timestamps are not taken from
the archive, git had to rehash every single file afterwards.

Replace the call to tar by helpers.unpack_tar, which compares each member
to the file that is already there and only writes it if it differs.
Superfluous elements in the target are removed afterwards, so the result
is the same as before. Each member is expected to occur only once in the
archive, but no specific order is required - anything that is in the way
of a member is cleared when that member is unpacked, including parent
elements that are not directories.

As before, timestamps from the archive are not applied. Permissions now
are applied exactly, which is what the sources intend: they set 2775 on
directories and 664 on files so the workdir becomes a group repository.
tar dropped the setgid bit (it only restores it with -p) and masked the
group write permission with the umask, so this only worked by accident of
the umask, if at all. The permissions of the extraction root itself, which
the archives carry as ".", are applied as well.